### PR TITLE
dlq for weblog and workflow/task topics

### DIFF
--- a/src/main/java/org/icgc_argo/workflow/relay/service/SplitterService.java
+++ b/src/main/java/org/icgc_argo/workflow/relay/service/SplitterService.java
@@ -35,8 +35,8 @@ public class SplitterService {
       log.debug("Processing workflow event");
       workflowOutput.send(MessageBuilder.withPayload(event).build());
     } else {
-      // TODO Use error topic
       log.error("Unhandled event: {}", event.toString());
+      throw new RuntimeException("Cannot handle event, please see DLQ for event information");
     }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,26 @@ spring:
       kafka:
         binder:
           brokers: localhost:9092
+          autoCreateTopics: true
+        bindings:
+          weblogout:
+            consumer:
+              enableDlq: true
+              dlqName: weblog_dlq
+              autoCommitOnError: true
+              autoCommitOffset: true
+          workflowindex:
+            consumer:
+              enableDlq: true
+              dlqName: workflow_dlq
+              autoCommitOnError: true
+              autoCommitOffset: true
+          taskindex:
+            consumer:
+              enableDlq: true
+              dlqName: task_dlq
+              autoCommitOnError: true
+              autoCommitOffset: true
       bindings:
         weblog:
           group: weblog


### PR DESCRIPTION
The elasticsearch indexing will throw an IOException after exhausting retries, and I manually throw a RuntimeException if the event cannot be handled at the splitter service. 

In either case, and exception causes spring to place the message into the corresponding dlq for the particular binding. 