### PR TITLE
2020 07 07 add jenkins deploy stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 def dockerHubRepo = "icgcargo/workflow-relay"
-def githubRepo = "icgc-argo/workflow-relay"
+def gitHubRepo = "icgc-argo/workflow-relay"
 def chartVersion = "0.2.0"
 def commit = "UNKNOWN"
 def version = "UNKNOWN"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ spec:
                     steps {
                         build(job: "/provision/helm", parameters: [
                             [$class: 'StringParameterValue', name: 'AP_RDPC_ENV', value: 'dev' ],
-                            [$class: 'StringParameterValue', name: 'AP_CHART_NAME', value: 'orkflow-relay'],
+                            [$class: 'StringParameterValue', name: 'AP_CHART_NAME', value: 'workflow-relay'],
                             [$class: 'StringParameterValue', name: 'AP_RELEASE_NAME', value: 'relay-weblog'],
                             [$class: 'StringParameterValue', name: 'AP_HELM_CHART_VERSION', value: "${chartVersion}"],
                             [$class: 'StringParameterValue', name: 'AP_ARGS_LINE', value: "--set-string image.tag=${version}-${commit}" ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,8 +84,7 @@ spec:
 
                 stage('deploy to rdpc-collab-dev') {
                     when {
-// Change branch to develop after successful testing
-                        branch "2020-07-07-add-jenkins-deploy-stage"
+                        branch "develop"
                     }
                     steps {
                         build(job: "/provision/helm", parameters: [
@@ -135,5 +134,35 @@ spec:
                         }
                     }
                 }
+
+                stage('deploy to rdpc-collab-qa') {
+                    when {
+                        branch "master"
+                    }
+                    steps {
+                        build(job: "/provision/helm", parameters: [
+                            [$class: 'StringParameterValue', name: 'AP_RDPC_ENV', value: 'qa' ],
+                            [$class: 'StringParameterValue', name: 'AP_CHART_NAME', value: 'workflow-relay'],
+                            [$class: 'StringParameterValue', name: 'AP_RELEASE_NAME', value: 'relay-weblog'],
+                            [$class: 'StringParameterValue', name: 'AP_HELM_CHART_VERSION', value: "${chartVersion}"],
+                            [$class: 'StringParameterValue', name: 'AP_ARGS_LINE', value: "--set-string image.tag=${version}" ]
+                        ])
+                        build(job: "/provision/helm", parameters: [
+                            [$class: 'StringParameterValue', name: 'AP_RDPC_ENV', value: 'qa' ],
+                            [$class: 'StringParameterValue', name: 'AP_CHART_NAME', value: 'workflow-relay'],
+                            [$class: 'StringParameterValue', name: 'AP_RELEASE_NAME', value: 'relay-splitter'],
+                            [$class: 'StringParameterValue', name: 'AP_HELM_CHART_VERSION', value: "${chartVersion}"],
+                            [$class: 'StringParameterValue', name: 'AP_ARGS_LINE', value: "--set-string image.tag=${version}" ]
+                        ])
+                        build(job: "/provision/helm", parameters: [
+                            [$class: 'StringParameterValue', name: 'AP_RDPC_ENV', value: 'qa' ],
+                            [$class: 'StringParameterValue', name: 'AP_CHART_NAME', value: 'workflow-relay'],
+                            [$class: 'StringParameterValue', name: 'AP_RELEASE_NAME', value: 'relay-index'],
+                            [$class: 'StringParameterValue', name: 'AP_HELM_CHART_VERSION', value: "${chartVersion}"],
+                            [$class: 'StringParameterValue', name: 'AP_ARGS_LINE', value: "--set-string image.tag=${version}" ]
+                        ])
+                    }
+                }
+
             }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,8 +90,22 @@ spec:
                     steps {
                         build(job: "/provision/helm", parameters: [
                             [$class: 'StringParameterValue', name: 'AP_RDPC_ENV', value: 'dev' ],
+                            [$class: 'StringParameterValue', name: 'AP_CHART_NAME', value: 'orkflow-relay'],
+                            [$class: 'StringParameterValue', name: 'AP_RELEASE_NAME', value: 'relay-weblog'],
+                            [$class: 'StringParameterValue', name: 'AP_HELM_CHART_VERSION', value: "${chartVersion}"],
+                            [$class: 'StringParameterValue', name: 'AP_ARGS_LINE', value: "--set-string image.tag=${version}-${commit}" ]
+                        ])
+                        build(job: "/provision/helm", parameters: [
+                            [$class: 'StringParameterValue', name: 'AP_RDPC_ENV', value: 'dev' ],
                             [$class: 'StringParameterValue', name: 'AP_CHART_NAME', value: 'workflow-relay'],
-                            [$class: 'StringParameterValue', name: 'AP_RELEASE_NAME', value: 'relay'],
+                            [$class: 'StringParameterValue', name: 'AP_RELEASE_NAME', value: 'relay-splitter'],
+                            [$class: 'StringParameterValue', name: 'AP_HELM_CHART_VERSION', value: "${chartVersion}"],
+                            [$class: 'StringParameterValue', name: 'AP_ARGS_LINE', value: "--set-string image.tag=${version}-${commit}" ]
+                        ])
+                        build(job: "/provision/helm", parameters: [
+                            [$class: 'StringParameterValue', name: 'AP_RDPC_ENV', value: 'dev' ],
+                            [$class: 'StringParameterValue', name: 'AP_CHART_NAME', value: 'workflow-relay'],
+                            [$class: 'StringParameterValue', name: 'AP_RELEASE_NAME', value: 'relay-index'],
                             [$class: 'StringParameterValue', name: 'AP_HELM_CHART_VERSION', value: "${chartVersion}"],
                             [$class: 'StringParameterValue', name: 'AP_ARGS_LINE', value: "--set-string image.tag=${version}-${commit}" ]
                         ])


### PR DESCRIPTION
* Pre-reqs: https://github.com/icgc-argo/rdpc-infra/pull/101
Dir structure for workflow-relay helm values was reorganized to allow reusability for Jenkins deploy job.
* Add deployment stage for develop and master branches. In each case workflow-relay chart is used to deploy 3 separate helm releases: relay-weblog, relay-splitter and relay-index. NOTE: A newly introduced relay-reindex service is not meant for automated CD process.
* develop branch scenario deployment to dev environment was tested successfully: 
https://jenkins.rdpc-dev.cancercollaboratory.org/blue/organizations/jenkins/workflow-relay/detail/2020-07-07-add-jenkins-deploy-stage/3/pipeline/38