### PR TITLE
marked certain text fields as simple for better search

### DIFF
--- a/src/main/resources/run_log_mapping.json
+++ b/src/main/resources/run_log_mapping.json
@@ -50,13 +50,15 @@
         "type": "date_nanos"
       },
       "repository": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "simple"
       },
       "exitStatus": {
         "type": "integer"
       },
       "commandLine":{
-        "type": "text"
+        "type": "text",
+        "analyzer": "simple"
       },
       "errorReport": {
         "type": "text"

--- a/src/main/resources/task_log_mapping.json
+++ b/src/main/resources/task_log_mapping.json
@@ -42,7 +42,8 @@
         "type": "integer"
       },
       "script": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "simple"
       },
       "workdir": {
         "type": "keyword"


### PR DESCRIPTION
the standard analyzer is meant for "natural language", given that these fields would all be not natural language but rather URLs or commands it makes sense to specify the simple analyzer

This will, along with the [Workflow-API PR](https://github.com/icgc-argo/workflow-api/pull/149), will resolve: https://github.com/icgc-argo/workflow-roadmap/issues/203