### PR TITLE
Racoon not clearing runs#12

### DIFF
--- a/src/main/java/org/icgc_argo/workflow/relay/util/OffsetDateTimeDeserializer.java
+++ b/src/main/java/org/icgc_argo/workflow/relay/util/OffsetDateTimeDeserializer.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Objects;
+
 import lombok.val;
 
 /** Utility class that converts "start" and "complete" json objects to OffsetDateTime. */
@@ -44,18 +46,22 @@ public class OffsetDateTimeDeserializer extends StdDeserializer<OffsetDateTime> 
   public OffsetDateTime deserialize(JsonParser jp, DeserializationContext ctxt)
       throws IOException, JsonProcessingException {
     JsonNode node = jp.getCodec().readTree(jp);
-    val offsetId = node.get("offset").get("id").textValue();
-    val zoneOffSet = ZoneOffset.of(offsetId);
+    val offset = node.get("offset");
+    if(Objects.nonNull(offset)) {
+      val offsetId = offset.get("id").textValue();
+      val zoneOffSet = ZoneOffset.of(offsetId);
 
-    return OffsetDateTime.of(
-        node.get("year").asInt(),
-        node.get("monthValue").asInt(),
-        node.get("dayOfMonth").asInt(),
-        node.get("hour").asInt(),
-        node.get("minute").asInt(),
-        node.get("second").asInt(),
-        node.get("nano").asInt(),
-        zoneOffSet);
+      return OffsetDateTime.of(
+          node.get("year").asInt(),
+          node.get("monthValue").asInt(),
+          node.get("dayOfMonth").asInt(),
+          node.get("hour").asInt(),
+          node.get("minute").asInt(),
+          node.get("second").asInt(),
+          node.get("nano").asInt(),
+          zoneOffSet);
+    }
+    return OffsetDateTime.parse(node.asText());
   }
 
   public static SimpleModule getOffsetDateTimeModule() {

--- a/src/main/java/org/icgc_argo/workflow/relay/util/OffsetDateTimeDeserializer.java
+++ b/src/main/java/org/icgc_argo/workflow/relay/util/OffsetDateTimeDeserializer.java
@@ -47,10 +47,10 @@ public class OffsetDateTimeDeserializer extends StdDeserializer<OffsetDateTime> 
       throws IOException, JsonProcessingException {
     JsonNode node = jp.getCodec().readTree(jp);
     val offset = node.get("offset");
+
     if(Objects.nonNull(offset)) {
       val offsetId = offset.get("id").textValue();
       val zoneOffSet = ZoneOffset.of(offsetId);
-
       return OffsetDateTime.of(
           node.get("year").asInt(),
           node.get("monthValue").asInt(),


### PR DESCRIPTION
When collab crashes, the jobs in progress get stuck in the Running state while their respective pods are in error. Running the racoon service should fix the status of these jobs. However, that does not happen due to a problem with the serialization and deserialization of the OffsetDateTime field in the workflow metadata. 